### PR TITLE
Fix: strcpy working bad with overlaping string

### DIFF
--- a/filename.c
+++ b/filename.c
@@ -38,7 +38,7 @@ char *filename_sanitize(const char *filename)
 			if (*p2 == '/')
 				p2++;
 
-			strcpy(p2, p1 + 4);
+			memmove(p2, p1 + 4, strlen(p1 + 4) + 1);
 		}
 	} while (p1);
 	return s;


### PR DESCRIPTION
With a big pathname `strcpy` doesn't work well, so I suggest you to use `memmove`. That what I changed in my commit.

For example, you can test it with **/home/networking/lina/sunflower/container/java/luna/kepler/../../sun/system/hello_world.c** string. For me it results:

- with `strcpy`: **/home/networking/lina/sunflower/container/java/luna/..m/he/system/hello_world.c**
- with `memmove`: **/home/networking/lina/sunflower/container/java/sun/system/hello_world.c**